### PR TITLE
同步优化版 PlanetMiner 实现并补充 Changlog.md

### DIFF
--- a/Changlog.md
+++ b/Changlog.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- 新增 BepInEx 配置项 `EnablePlanetRadiusLimit`，用于控制是否启用行星半径限制。
+- 新增 BepInEx 配置项 `MaxPlanetRadius`，用于控制 PlanetMiner 生效的最大行星半径。
+- 新增按工厂保存的 `FactoryState`，用于缓存矿脉索引、石油小数余量和采矿消耗余量。
+- 新增 `OilFractionState`，用于累计石油产量的小数部分。
+- 新增 `MyPluginInfo`，并统一插件 GUID、名称与版本号。
+
+### Changed
+
+- 将 `PlanetMiner/PlanetMiner/PlanetMiner.cs` 的实现替换为从 `PlanetMiner-HerSophia/src/PlanetMiner.cs` 同步过来的优化版实现。
+- 将节流基准从 `Update()` 中维护的 `frame` 改为 `GameMain.gameTick`。
+- 使用 `(tick + factoryIndex) % interval` 让不同行星错峰执行，减少同一时刻的集中计算。
+- 将 Weaver 兼容检查中的反射元数据改为首次解析后缓存，避免每次 tick 重复解析。
+- 将矿脉扫描改为按工厂缓存，在正常情况下不再每次全量遍历 `veinPool`。
+- 将燃料热值查询改为缓存。
+- 将石油类型判定改为缓存。
+- 将 `GenerateEnergy()` 的调用收敛为每个站点在一次处理流程中最多执行一次。
+- 将采矿消耗余量 `costFrac` 从全局静态字段改为按工厂独立保存。
+- 将石油产量计算从直接截断改为累计小数余量后再结算整数产出。
+
+### Fixed
+
+- 修正取水分支不检查能量的问题。现在能量不足时不会继续产水。
+- 修正 `productRegister[itemId]` 直接写入可能产生越界的问题，增加了边界检查。
+- 修正采矿时可能继续使用失效矿脉索引的问题，缓存失效后会触发重建。
+- 修正多工厂并行执行时共享 `costFrac` 可能互相影响的问题。
+- 修正 Weaver 初始化过程中可能出现的并发读取半初始化状态的问题。
+
+### Notes
+
+- 默认配置下，PlanetMiner 只在 `planet.radius < 100` 的行星上生效。
+- 修改配置文件后无需重启游戏即可生效。
+- 本次修改主要用于同步 `PlanetMiner-HerSophia/src/PlanetMiner.cs` 中已经整理完成的优化与修正。

--- a/PlanetMiner/PlanetMiner.cs
+++ b/PlanetMiner/PlanetMiner.cs
@@ -1,203 +1,699 @@
-﻿using BepInEx;
-using HarmonyLib;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Security.Policy;
-using UnityEngine;
+using System.Reflection;
+using BepInEx;
+using BepInEx.Configuration;
+using HarmonyLib;
 
 namespace PlanetMiner
 {
-    [BepInPlugin("crecheng.PlanetMiner", "PlanetMiner", Version)]
+    [BepInPlugin("crecheng.PlanetMiner", "PlanetMiner", "3.1.4")]
     public class PlanetMiner : BaseUnityPlugin
     {
-
         public const string Version = "3.1.4";
-        public const int uesEnergy = 20_000_000;
+        public const float DefaultMaxPlanetRadius = 100f;
+        public const int uesEnergy = 20000000;
+
+        private static volatile bool _enablePlanetRadiusLimit = true;
+        private static volatile float _maxPlanetRadius = DefaultMaxPlanetRadius;
+
+        private ConfigEntry<bool> _enablePlanetRadiusLimitConfig;
+        private ConfigEntry<float> _maxPlanetRadiusConfig;
+
+        private sealed class FactoryState
+        {
+            public readonly object SyncRoot = new object();
+            public readonly Dictionary<int, List<int>> VeinsByItem = new Dictionary<int, List<int>>(64);
+            public readonly Stack<List<int>> ListPool = new Stack<List<int>>();
+            public readonly Dictionary<long, OilFractionState> OilFractions = new Dictionary<long, OilFractionState>();
+
+            public PlanetFactory Factory;
+            public VeinData[] VeinPool;
+            public int PlanetId;
+            public double CostFrac;
+            public bool RebuildRequested = true;
+        }
+
+        private struct OilFractionState
+        {
+            public readonly int ItemId;
+            public readonly double Fraction;
+
+            public OilFractionState(int itemId, double fraction)
+            {
+                ItemId = itemId;
+                Fraction = fraction;
+            }
+        }
+
+        private static volatile bool _weaverResolved;
+        private static bool _weaverAvailable;
+        private static MethodInfo _getOptimizedPlanetMethod;
+        private static PropertyInfo _statusProperty;
+        private static object _runningEnumValue;
+        private static readonly object _weaverInitLock = new object();
+
+        private static readonly ConcurrentDictionary<int, long> _heatValueCache = new ConcurrentDictionary<int, long>();
+        private static readonly ConcurrentDictionary<int, bool> _oilItemCache = new ConcurrentDictionary<int, bool>();
+        private static readonly ConcurrentDictionary<int, FactoryState> _stateByFactory = new ConcurrentDictionary<int, FactoryState>();
+
+
+        private static void EnsureWeaverResolved()
+        {
+            if (_weaverResolved)
+            {
+                return;
+            }
+
+            lock (_weaverInitLock)
+            {
+                if (_weaverResolved)
+                {
+                    return;
+                }
+
+                try
+                {
+                    Type iOptimizedPlanet = Type.GetType("Weaver.Optimizations.IOptimizedPlanet, DSP_Weaver");
+                    if (iOptimizedPlanet == null)
+                    {
+                        return;
+                    }
+
+                    Type starCluster = Type.GetType("Weaver.Optimizations.OptimizedStarCluster, DSP_Weaver");
+                    if (starCluster == null)
+                    {
+                        return;
+                    }
+
+                    MethodInfo method = starCluster.GetMethod("GetOptimizedPlanet", BindingFlags.Static | BindingFlags.Public);
+                    if (method == null)
+                    {
+                        return;
+                    }
+
+                    PropertyInfo property = iOptimizedPlanet.GetProperty("Status");
+                    if (property == null)
+                    {
+                        return;
+                    }
+
+                    Type statusEnum = Type.GetType("Weaver.Optimizations.OptimizedPlanetStatus, DSP_Weaver");
+                    if (statusEnum == null)
+                    {
+                        return;
+                    }
+
+                    _getOptimizedPlanetMethod = method;
+                    _statusProperty = property;
+                    _runningEnumValue = Enum.Parse(statusEnum, "Running");
+                    _weaverAvailable = true;
+                }
+                catch
+                {
+                    _weaverAvailable = false;
+                }
+                finally
+                {
+                    _weaverResolved = true;
+                }
+            }
+        }
+
+        private static bool IsOptimizedByWeaver(FactorySystem factorySystem)
+        {
+            EnsureWeaverResolved();
+            if (!_weaverAvailable)
+            {
+                return false;
+            }
+
+            try
+            {
+                object[] args = new object[] { factorySystem.planet };
+                object optimizedPlanet = _getOptimizedPlanetMethod.Invoke(null, args);
+                if (optimizedPlanet == null)
+                {
+                    return false;
+                }
+
+                object status = _statusProperty.GetValue(optimizedPlanet);
+                return status != null && status.Equals(_runningEnumValue);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static long GetHeatValue(int itemId)
+        {
+            if (_heatValueCache.TryGetValue(itemId, out long value))
+            {
+                return value;
+            }
+
+            ItemProto proto = ((ProtoSet<ItemProto>)(object)LDB.items).Select(itemId);
+            value = proto?.HeatValue ?? 0L;
+            _heatValueCache.TryAdd(itemId, value);
+            return value;
+        }
+
+        private static bool IsOilItem(int itemId)
+        {
+            if (_oilItemCache.TryGetValue(itemId, out bool value))
+            {
+                return value;
+            }
+
+            value = (int)LDB.veins.GetVeinTypeByItemId(itemId) == 7;
+            _oilItemCache.TryAdd(itemId, value);
+            return value;
+        }
+
+        private static long MakeSlotKey(int stationIndex, int slotIndex)
+        {
+            return ((long)stationIndex << 32) | (uint)slotIndex;
+        }
+
+        private static void ClearOilFraction(FactoryState state, int stationIndex, int slotIndex)
+        {
+            state.OilFractions.Remove(MakeSlotKey(stationIndex, slotIndex));
+        }
+
+        private static int AccumulateOilOutput(FactoryState state, int stationIndex, int slotIndex, int itemId, double produced)
+        {
+            if (produced <= 0.0)
+            {
+                return 0;
+            }
+
+            long key = MakeSlotKey(stationIndex, slotIndex);
+            double total = produced;
+            if (state.OilFractions.TryGetValue(key, out OilFractionState saved) && saved.ItemId == itemId)
+            {
+                total += saved.Fraction;
+            }
+
+            int addInt = (int)total;
+            double remain = total - addInt;
+            if (remain > 0.0)
+            {
+                state.OilFractions[key] = new OilFractionState(itemId, remain);
+            }
+            else
+            {
+                state.OilFractions.Remove(key);
+            }
+
+            return addInt;
+        }
+
+        private static void AddProductStat(int[] productRegister, int itemId, int amount)
+        {
+            if (productRegister == null || amount <= 0)
+            {
+                return;
+            }
+
+            if ((uint)itemId < (uint)productRegister.Length)
+            {
+                productRegister[itemId] += amount;
+            }
+        }
+
+        private static void RecycleVeinLists(FactoryState state)
+        {
+            foreach (KeyValuePair<int, List<int>> pair in state.VeinsByItem)
+            {
+                pair.Value.Clear();
+                state.ListPool.Push(pair.Value);
+            }
+            state.VeinsByItem.Clear();
+        }
+
+        private static List<int> AcquireVeinList(FactoryState state)
+        {
+            return state.ListPool.Count > 0 ? state.ListPool.Pop() : new List<int>(8);
+        }
+
+        private static void RebuildVeinCache(FactoryState state, VeinData[] veinPool)
+        {
+            RecycleVeinLists(state);
+
+            if (veinPool != null)
+            {
+                for (int i = 0; i < veinPool.Length; i++)
+                {
+                    VeinData vein = veinPool[i];
+                    if (vein.amount > 0 && vein.productId > 0)
+                    {
+                        if (!state.VeinsByItem.TryGetValue(vein.productId, out List<int> list))
+                        {
+                            list = AcquireVeinList(state);
+                            state.VeinsByItem[vein.productId] = list;
+                        }
+                        list.Add(i);
+                    }
+                }
+            }
+
+            state.RebuildRequested = false;
+        }
+
+        private static void PrepareFactoryState(FactoryState state, PlanetFactory factory, int planetId)
+        {
+            VeinData[] veinPool = factory.veinPool;
+            bool factoryChanged = !ReferenceEquals(state.Factory, factory)
+                || !ReferenceEquals(state.VeinPool, veinPool)
+                || state.PlanetId != planetId;
+
+            if (factoryChanged)
+            {
+                state.Factory = factory;
+                state.VeinPool = veinPool;
+                state.PlanetId = planetId;
+                state.CostFrac = 0.0;
+                state.OilFractions.Clear();
+                state.RebuildRequested = true;
+            }
+
+            if (state.RebuildRequested)
+            {
+                RebuildVeinCache(state, veinPool);
+            }
+        }
+
+        private static double SumOilOutput(List<int> indices, VeinData[] veinPool, int itemId, out bool cacheStale)
+        {
+            cacheStale = false;
+            if (veinPool == null)
+            {
+                return 0.0;
+            }
+
+            double produced = 0.0;
+            int count = indices.Count;
+            for (int i = 0; i < count; i++)
+            {
+                int index = indices[i];
+                if (index < 0 || index >= veinPool.Length)
+                {
+                    cacheStale = true;
+                    break;
+                }
+
+                VeinData vein = veinPool[index];
+                if (vein.productId != itemId || vein.amount <= 0)
+                {
+                    cacheStale = true;
+                    break;
+                }
+
+                produced += vein.amount / 6000.0;
+            }
+
+            return produced;
+        }
+
+        private static bool TryMine(VeinData[] veinPool, int index, int itemId, float miningRate, PlanetFactory factory, ref double costFrac, out bool cacheStale)
+        {
+            cacheStale = false;
+            if (veinPool == null || index < 0 || index >= veinPool.Length)
+            {
+                cacheStale = true;
+                return false;
+            }
+
+            if (veinPool[index].productId != itemId)
+            {
+                cacheStale = true;
+                return false;
+            }
+
+            if (veinPool[index].amount > 0)
+            {
+                bool consume = false;
+                if (miningRate > 0f)
+                {
+                    costFrac += miningRate;
+                    consume = (int)costFrac > 0;
+                    if (consume)
+                    {
+                        costFrac -= 1.0;
+                    }
+                }
+
+                if (consume)
+                {
+                    veinPool[index].amount = veinPool[index].amount - 1;
+                    factory.veinGroups[veinPool[index].groupIndex].amount--;
+                    if (veinPool[index].amount <= 0)
+                    {
+                        short groupIndex = veinPool[index].groupIndex;
+                        factory.veinGroups[groupIndex].count--;
+                        factory.RemoveVeinWithComponents(index);
+                        factory.RecalculateVeinGroup(groupIndex);
+                        cacheStale = true;
+                    }
+                }
+
+                return true;
+            }
+
+            short emptyGroupIndex = veinPool[index].groupIndex;
+            factory.veinGroups[emptyGroupIndex].count--;
+            factory.RemoveVeinWithComponents(index);
+            factory.RecalculateVeinGroup(emptyGroupIndex);
+            cacheStale = true;
+            return false;
+        }
+
         private void Start()
         {
+            _enablePlanetRadiusLimitConfig = Config.Bind(
+                "Gameplay",
+                "EnablePlanetRadiusLimit",
+                true,
+                "Whether PlanetMiner is limited by planet radius.");
+
+            _maxPlanetRadiusConfig = Config.Bind(
+                "Gameplay",
+                "MaxPlanetRadius",
+                DefaultMaxPlanetRadius,
+                "PlanetMiner works only when planet.radius is smaller than this value.");
+
+            ApplyConfigValues();
+            _enablePlanetRadiusLimitConfig.SettingChanged += OnConfigSettingChanged;
+            _maxPlanetRadiusConfig.SettingChanged += OnConfigSettingChanged;
+
             Harmony.CreateAndPatchAll(typeof(PlanetMiner), null);
         }
-        private void Update()
+
+        private void OnConfigSettingChanged(object sender, EventArgs e)
         {
-            frame += 1L;
+            ApplyConfigValues();
+        }
+
+        private void ApplyConfigValues()
+        {
+            _enablePlanetRadiusLimit = _enablePlanetRadiusLimitConfig == null || _enablePlanetRadiusLimitConfig.Value;
+            float configuredRadius = _maxPlanetRadiusConfig?.Value ?? DefaultMaxPlanetRadius;
+            _maxPlanetRadius = configuredRadius > 0f ? configuredRadius : DefaultMaxPlanetRadius;
         }
 
         [HarmonyPostfix]
         [HarmonyPatch(typeof(FactorySystem), "GameTickLabResearchMode")]
         private static void Miner(FactorySystem __instance)
         {
-            GameHistoryData history = GameMain.history;
-            float miningSpeedScale = history.miningSpeedScale;
-            if (miningSpeedScale <= 0)
+            if (__instance == null || __instance.planet == null)
             {
                 return;
             }
-            int baseSpeed = (int)(120f / miningSpeedScale);
-            baseSpeed = baseSpeed <= 0 ? 1 : baseSpeed;
-            if (frame % baseSpeed != 0) return;
-            VeinData[] veinPool = __instance.factory.veinPool;
-            Dictionary<int, List<int>> veins = new Dictionary<int, List<int>>();
-            for (int i = 0; i < veinPool.Length; i++)
-            {
-                VeinData veinData = veinPool[i];
-                if (veinData.amount > 0 && veinData.productId > 0)
-                {
-                    AddVeinData(veins, veinData.productId, i);
-                }
-            }
-            float miningRate = history.miningCostRate;
-            PlanetTransport transport = __instance.planet.factory.transport;
-            FactoryProductionStat factoryProductionStat = GameMain.statistics.production.factoryStatPool[__instance.factory.index];
-            int[] productRegister = factoryProductionStat?.productRegister;
-            foreach (var sc in transport.stationPool)
-            {
-                if (sc?.storage == null) continue;
-                for (int k = 0; k < sc.storage.Length; k++)
-                {
-                    StationStore stationStore = sc.storage[k];
-                    int itemID = stationStore.itemId;
-                    if (stationStore.count < 0) sc.storage[k].count = 0;
-                    if (stationStore.localLogic != ELogisticStorage.Demand)
-                    {
-                        continue;
-                    }
-                    GenerateEnergy(sc);
 
-                    if (stationStore.max <= stationStore.count)
+            GameHistoryData history = GameMain.history;
+            if (history == null)
+            {
+                return;
+            }
+
+            float miningSpeedScale = history.miningSpeedScale;
+            if (miningSpeedScale <= 0f)
+            {
+                return;
+            }
+
+            PlanetFactory factory = __instance.factory;
+            if (factory == null)
+            {
+                return;
+            }
+
+            PlanetData planet = __instance.planet;
+            if (planet == null)
+            {
+                return;
+            }
+
+            if (_enablePlanetRadiusLimit && planet.radius >= _maxPlanetRadius)
+            {
+                return;
+            }
+
+            int interval = (int)(120f / miningSpeedScale);
+            if (interval <= 0)
+            {
+                interval = 1;
+            }
+
+            int factoryIndex = factory.index;
+            long tick = GameMain.gameTick;
+            if ((tick + factoryIndex) % interval != 0)
+            {
+                return;
+            }
+
+            if (IsOptimizedByWeaver(__instance))
+            {
+                return;
+            }
+
+            PlanetTransport transport = factory.transport;
+            if (transport == null || transport.stationPool == null)
+            {
+                return;
+            }
+
+            FactoryState state = _stateByFactory.GetOrAdd(factoryIndex, _ => new FactoryState());
+            lock (state.SyncRoot)
+            {
+                PrepareFactoryState(state, factory, __instance.planet.id);
+                VeinData[] veinPool = state.VeinPool;
+
+                int[] productRegister = null;
+                if (GameMain.statistics != null && GameMain.statistics.production != null)
+                {
+                    FactoryProductionStat[] factoryStatPool = GameMain.statistics.production.factoryStatPool;
+                    if (factoryStatPool != null && (uint)factoryIndex < (uint)factoryStatPool.Length)
+                    {
+                        FactoryProductionStat stat = factoryStatPool[factoryIndex];
+                        productRegister = stat?.productRegister;
+                    }
+                }
+
+                int waterItemId = __instance.planet.waterItemId;
+                float miningCostRate = history.miningCostRate;
+                StationComponent[] stationPool = transport.stationPool;
+                double costFrac = state.CostFrac;
+
+                for (int s = 0; s < stationPool.Length; s++)
+                {
+                    StationComponent station = stationPool[s];
+                    if (station?.storage == null)
                     {
                         continue;
                     }
-                    if (veins.ContainsKey(itemID))
+
+                    StationStore[] storage = station.storage;
+                    bool generatedEnergy = false;
+
+                    for (int k = 0; k < storage.Length; k++)
                     {
-                        if (sc.energy < uesEnergy) continue;
-                        float count = 0;
-                        bool isoil = LDB.veins.GetVeinTypeByItemId(itemID) == EVeinType.Oil;
-                        foreach (int index in veins[itemID])
+                        StationStore slot = storage[k];
+                        if (slot.count < 0)
                         {
-                            if (isoil)
+                            slot.count = 0;
+                            storage[k].count = 0;
+                        }
+
+                        int itemId = slot.itemId;
+                        if ((int)slot.localLogic != 2)
+                        {
+                            ClearOilFraction(state, s, k);
+                            continue;
+                        }
+
+                        if (itemId <= 0)
+                        {
+                            ClearOilFraction(state, s, k);
+                            continue;
+                        }
+
+                        bool hasVeins = state.VeinsByItem.TryGetValue(itemId, out List<int> indices);
+                        bool isOil = hasVeins && IsOilItem(itemId);
+                        if (!isOil)
+                        {
+                            ClearOilFraction(state, s, k);
+                        }
+
+                        if (slot.max <= slot.count)
+                        {
+                            continue;
+                        }
+
+                        if (hasVeins)
+                        {
+                            if (station.energy < uesEnergy && !generatedEnergy)
                             {
-                                count += veinPool.Length > index && veinPool[index].productId > 0 ? veinPool[index].amount / 6000f : 0;
+                                GenerateEnergy(station);
+                                generatedEnergy = true;
+                            }
+
+                            if (station.energy < uesEnergy)
+                            {
+                                continue;
+                            }
+
+                            int addInt = 0;
+                            if (isOil)
+                            {
+                                double produced = SumOilOutput(indices, veinPool, itemId, out bool cacheStale);
+                                if (cacheStale)
+                                {
+                                    RebuildVeinCache(state, veinPool);
+                                    if (!state.VeinsByItem.TryGetValue(itemId, out indices))
+                                    {
+                                        ClearOilFraction(state, s, k);
+                                        continue;
+                                    }
+
+                                    produced = SumOilOutput(indices, veinPool, itemId, out cacheStale);
+                                    if (cacheStale)
+                                    {
+                                        state.RebuildRequested = true;
+                                        continue;
+                                    }
+                                }
+
+                                addInt = AccumulateOilOutput(state, s, k, itemId, produced);
                             }
                             else
                             {
-                                count += GetMine(veinPool, index, miningRate, __instance.planet.factory) ? 1 : 0;
+                                int count = indices.Count;
+                                bool cacheStale = false;
+                                for (int i = 0; i < count; i++)
+                                {
+                                    if (TryMine(veinPool, indices[i], itemId, miningCostRate, factory, ref costFrac, out bool changedCache))
+                                    {
+                                        addInt++;
+                                    }
+
+                                    if (changedCache)
+                                    {
+                                        cacheStale = true;
+                                        break;
+                                    }
+                                }
+
+                                if (cacheStale)
+                                {
+                                    RebuildVeinCache(state, veinPool);
+                                }
                             }
+
+                            if (addInt <= 0)
+                            {
+                                continue;
+                            }
+
+                            storage[k].count += addInt;
+                            AddProductStat(productRegister, itemId, addInt);
+                            station.energy -= uesEnergy;
                         }
-                        sc.storage[k].count += (int)count;
-                        productRegister[itemID] += factoryProductionStat != null ? (int)count : 0;
-                        sc.energy -= uesEnergy;
-                    }
-                    else
-                    {
-                        if (itemID == __instance.planet.waterItemId)
+                        else if (itemId == waterItemId)
                         {
-                            sc.storage[k].count += 100;
-                            productRegister[itemID] += factoryProductionStat != null ? 100 : 0;
-                            sc.energy -= uesEnergy;
+                            if (station.energy < uesEnergy && !generatedEnergy)
+                            {
+                                GenerateEnergy(station);
+                                generatedEnergy = true;
+                            }
+
+                            if (station.energy < uesEnergy)
+                            {
+                                continue;
+                            }
+
+                            storage[k].count += 100;
+                            AddProductStat(productRegister, itemId, 100);
+                            station.energy -= uesEnergy;
                         }
                     }
                 }
+
+                state.CostFrac = costFrac;
             }
         }
 
-        private static void GenerateEnergy(StationComponent sc)
+        private static void GenerateEnergy(StationComponent station)
         {
-            var SecondtolastIndex = sc.storage.Length - 2;
-            //当能量不足一半时
-            if (SecondtolastIndex<0 || SecondtolastIndex >= sc.storage.Length || sc.energyMax / 2 <= sc.energy)
+            int fuelIndex = station.storage.Length - 2;
+            if (fuelIndex < 0 || fuelIndex >= station.storage.Length)
             {
                 return;
             }
-            //获取倒数第二个物品栏
 
-            StationStore fuelStore = sc.storage[SecondtolastIndex];
-            int fuelitemId = fuelStore.itemId;
-            int fuelcount = fuelStore.count;
-            if (fuelitemId <= 0 || fuelcount <= 0)
+            if (station.energyMax / 2 <= station.energy)
             {
                 return;
             }
-            //获取物品的能量值
-            long heatValue = LDB.items.Select(fuelitemId)?.HeatValue ?? 0;
-            if (heatValue <= 0)
+
+            StationStore fuel = station.storage[fuelIndex];
+            int itemId = fuel.itemId;
+            int count = fuel.count;
+            if (itemId <= 0 || count <= 0)
             {
                 return;
             }
-            //获取需要充电的能量
-            int needcount = Math.Min((int)((sc.energyMax - sc.energy) / heatValue), fuelcount); ;
-            int usedInc = split_inc_level(ref fuelStore.count, ref fuelStore.inc, needcount);
-            double num = 1;
-            if (needcount > 0 && usedInc > 0)
+
+            long heat = GetHeatValue(itemId);
+            if (heat <= 0)
             {
-                int inclevel = usedInc / needcount;
-                if (inclevel >= 0 && inclevel < Cargo.incTableMilli.Length)
+                return;
+            }
+
+            int need = (int)((station.energyMax - station.energy) / heat);
+            if (need > count)
+            {
+                need = count;
+            }
+            if (need <= 0)
+            {
+                return;
+            }
+
+            int usedInc = split_inc_level(ref fuel.count, ref fuel.inc, need);
+            double multiplier = 1.0;
+            if (need > 0 && usedInc > 0)
+            {
+                int level = usedInc / need;
+                if (level >= 0 && level < Cargo.incTableMilli.Length)
                 {
-                    num += Cargo.incTableMilli[inclevel];
+                    multiplier += Cargo.incTableMilli[level];
                 }
             }
-            sc.energy += (long)(needcount * heatValue * num);
-            sc.storage[SecondtolastIndex].inc = fuelStore.inc;
-            sc.storage[SecondtolastIndex].count = fuelStore.count;
+
+            station.energy += (long)((double)(need * heat) * multiplier);
+            station.storage[fuelIndex].inc = fuel.inc;
+            station.storage[fuelIndex].count = fuel.count;
         }
 
-        private static void AddVeinData(Dictionary<int, List<int>> veins, int item, int index)
-        {
-            bool flag = !veins.ContainsKey(item);
-            if (flag)
-            {
-                veins.Add(item, new List<int>());
-            }
-            veins[item].Add(index);
-        }
-
-        public static bool GetMine(VeinData[] veinDatas, int index, float miningRate, PlanetFactory factory)
-        {
-            if (veinDatas.Length <= 0 || veinDatas[index].productId <= 0) return false;
-            if (veinDatas[index].amount > 0)
-            {
-                bool flag = false;
-                if (miningRate > 0)
-                {
-                    costFrac += miningRate;
-                    flag = (int)costFrac > 0;
-                    costFrac -= flag?1:0;
-                }
-                if (flag)
-                {
-                    veinDatas[index].amount = veinDatas[index].amount - 1;
-                    factory.veinGroups[veinDatas[index].groupIndex].amount -= 1;
-                    if (veinDatas[index].amount <= 0)
-                    {
-                        short groupIndex = veinDatas[index].groupIndex;
-                        factory.veinGroups[groupIndex].count -= 1;
-                        factory.RemoveVeinWithComponents(index);
-                        factory.RecalculateVeinGroup(groupIndex);
-                    }
-                }
-                return true;
-            }
-            else
-            {
-                short groupIndex2 = veinDatas[index].groupIndex;
-                factory.veinGroups[groupIndex2].count -= 1;
-                factory.RemoveVeinWithComponents(index);
-                factory.RecalculateVeinGroup(groupIndex2);
-                return false;
-            }
-        }
-
-        private static long frame = 0L;
-
-        private static double costFrac = 0;
         private static int split_inc_level(ref int count, ref int totalinc, int requireCount)
         {
-            int usedInc = totalinc / count;
-            int num2 = totalinc - usedInc * count;
+            int a = totalinc / count;
+            int b = totalinc - a * count;
             count -= requireCount;
-            num2 -= count;
-            usedInc = ((num2 > 0) ? (usedInc * requireCount + num2) : (usedInc * requireCount));
-            totalinc -= usedInc;
-            return usedInc;
+            b -= count;
+            a = b > 0 ? (a * requireCount + b) : (a * requireCount);
+            totalinc -= a;
+            return a;
         }
+    }
+
+    public static class MyPluginInfo
+    {
+        public const string PLUGIN_GUID = "crecheng.PlanetMiner";
+        public const string PLUGIN_NAME = "PlanetMiner";
+        public const string PLUGIN_VERSION = "3.1.4";
     }
 }


### PR DESCRIPTION
## 概要

本 PR 将已整理完成的优化版 `PlanetMiner.cs` 同步到上游仓库，并补充一份 `Changlog.md` 便于审阅。

## 主要修改

- 缓存 Weaver 兼容检查所需的反射元数据，避免每个 tick 重复解析
- 将节流基准从 `Update()` 中的 `frame` 改为 `GameMain.gameTick`
- 使用 `factoryIndex` 错开不同行星的执行时机，减少集中计算
- 按工厂缓存矿脉索引，避免每次触发都全量扫描 `veinPool`
- 将 `costFrac` 从全局静态字段改为按工厂保存
- 为石油产量累计小数余量，减少长期运行时的截断损失
- 为取水分支补上能量检查
- 为 `productRegister` 写入增加边界检查
- 新增基于 BepInEx 的行星半径限制配置
- 新增 `Changlog.md` 说明本次修改内容

## 构建验证

已在本地编译通过：

- `dotnet build PlanetMiner/PlanetMiner.csproj -c Release`
- 结果：`0 warnings, 0 errors`

## 说明

编译验证时使用了本地 DSP 依赖路径，但这些临时引用路径没有保留到最终提交中。