### PR TITLE
调整默认配置 & 修复与 OrbitalRing-MOD 的兼容问题

### DIFF
--- a/PlanetMiner/PlanetMiner.cs
+++ b/PlanetMiner/PlanetMiner.cs
@@ -167,7 +167,12 @@ namespace PlanetMiner
                 return value;
             }
 
-            value = (int)LDB.veins.GetVeinTypeByItemId(itemId) == 7;
+            // Vein type 7 = Oil (vanilla)
+            // Vein type 16 = DeepMagma, 19 = Ice (OrbitalRing-MOD)
+            // These are all rate-based veins (oil-like) whose amount represents
+            // production speed, not a finite stockpile.
+            int veinType = (int)LDB.veins.GetVeinTypeByItemId(itemId);
+            value = veinType == 7 || veinType == 16 || veinType == 19;
             _oilItemCache.TryAdd(itemId, value);
             return value;
         }

--- a/PlanetMiner/PlanetMiner.cs
+++ b/PlanetMiner/PlanetMiner.cs
@@ -15,7 +15,7 @@ namespace PlanetMiner
         public const float DefaultMaxPlanetRadius = 100f;
         public const int uesEnergy = 20000000;
 
-        private static volatile bool _enablePlanetRadiusLimit = true;
+        private static volatile bool _enablePlanetRadiusLimit = false;
         private static volatile float _maxPlanetRadius = DefaultMaxPlanetRadius;
 
         private ConfigEntry<bool> _enablePlanetRadiusLimitConfig;
@@ -375,7 +375,7 @@ namespace PlanetMiner
             _enablePlanetRadiusLimitConfig = Config.Bind(
                 "Gameplay",
                 "EnablePlanetRadiusLimit",
-                true,
+                false,
                 "Whether PlanetMiner is limited by planet radius.");
 
             _maxPlanetRadiusConfig = Config.Bind(
@@ -398,7 +398,7 @@ namespace PlanetMiner
 
         private void ApplyConfigValues()
         {
-            _enablePlanetRadiusLimit = _enablePlanetRadiusLimitConfig == null || _enablePlanetRadiusLimitConfig.Value;
+            _enablePlanetRadiusLimit = _enablePlanetRadiusLimitConfig != null && _enablePlanetRadiusLimitConfig.Value;
             float configuredRadius = _maxPlanetRadiusConfig?.Value ?? DefaultMaxPlanetRadius;
             _maxPlanetRadius = configuredRadius > 0f ? configuredRadius : DefaultMaxPlanetRadius;
         }


### PR DESCRIPTION
## 改动内容

### 1. EnablePlanetRadiusLimit 默认值改为 false

将 `EnablePlanetRadiusLimit` 的默认值从 `true` 改为 `false`。

原先默认启用半径限制，大行星上的物流塔不会自动采矿，新用户容易在不知情的情况下误以为 mod 未生效。改为默认关闭后，所有行星均可自动采集，与原版 PlanetMiner 行为一致。如需限制，可在配置文件中手动开启。

涉及三处修改：
- 字段初始值
- `Config.Bind` 默认值
- `ApplyConfigValues` 中配置为 null 时的回退逻辑

### 2. 兼容 OrbitalRing-MOD 的产速型矿脉

OrbitalRing-MOD 通过 preloader 向 `EVeinType` 枚举新增了 `DeepMagma`（深层熔岩，16）和 `Ice`（地下冰层，19）两种矿脉类型。它们与原油一样属于产速型矿脉，`amount` 表示每秒产量而非有限储量。OrbitalRing-MOD 已在 `MinerComponent.InternalUpdate` 中将深层熔岩的衰减率设为 0，确保永不衰减。

但 PlanetMiner 的 `IsOilItem()` 只判断 `veinType == 7`（原油），不识别 16 和 19，导致深层熔岩和地下冰层被当作普通固体矿处理，走 `TryMine` 路径逐次扣减 amount，最终被挖空——即使在无限资源的游戏设置下也是如此。

修复方式：将 `IsOilItem()` 的判定条件扩展为 `veinType == 7 || veinType == 16 || veinType == 19`，使这两种矿脉走 `SumOilOutput` 路径，按产速计算输出，不消耗矿脉数量。

未安装 OrbitalRing-MOD 时不受影响：`GetVeinTypeByItemId` 不会返回 16 或 19，相关 itemId 也不存在于游戏数据中。"